### PR TITLE
Replace ty with pyright

### DIFF
--- a/.config/nvim/lua/plugins/lsp.lua
+++ b/.config/nvim/lua/plugins/lsp.lua
@@ -50,12 +50,19 @@ return {
           },
         },
       },
-      ty = {
-        cmd = { "ty", "server" },
+      ["pyright"] = {
+        cmd = { "pyright-langserver", "--stdio" },
         filetypes = { "python" },
         root_markers = { "pyproject.toml", "setup.py", "setup.cfg", "requirements.txt", "Pipfile", ".git" },
+        name = "pyright",
         settings = {
-          ty = {},
+          python = {
+            analysis = {
+              autoSearchPaths = true,
+              useLibraryCodeForTypes = true,
+              diagnosticMode = "openFilesOnly",
+            },
+          },
         },
       },
     }


### PR DESCRIPTION
# Summary
**Title:** Replace ty with pyright

Reviewers: miguelcsilva

## Description
Replaced the `ty` language server with `pyright` for Python development. Pyright is a more widely adopted and actively maintained Python language server that provides comprehensive type checking and IDE features.

## Changes
- Updated LSP configuration in `.config/nvim/lua/plugins/lsp.lua`
- Replaced `ty` server command with `pyright-langserver --stdio`
- Updated settings structure to use standard pyright configuration
- Configured pyright with auto search paths, library code types, and open files diagnostic mode

## Additional Notes
This change improves Python development experience with better type checking and language server capabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)