### PR TITLE
Update navigation keybindings for tmux and Neovim

### DIFF
--- a/.config/kitty/kitty.conf
+++ b/.config/kitty/kitty.conf
@@ -8,6 +8,12 @@ macos_option_as_alt yes
 # Keybindings
 map ctrl+v paste_from_clipboard
 
+# Pass Ctrl+Shift+Arrow to applications (for Neovim navigation)
+map ctrl+shift+left no_op
+map ctrl+shift+right no_op
+map ctrl+shift+up no_op
+map ctrl+shift+down no_op
+
 # Font
 font_size        16
 font_family      family="JetBrainsMonoNL Nerd Font Mono"

--- a/.config/nvim/lua/config/keymaps.lua
+++ b/.config/nvim/lua/config/keymaps.lua
@@ -17,10 +17,10 @@ vim.keymap.set("v", "<", "<gv", { desc = "Indent lines left" })
 vim.keymap.set("v", ">", ">gv", { desc = "Indent lines right" })
 
 -- Jumping windows
-vim.keymap.set("n", "<C-Left>", "<C-w>h", { desc = "Move focus to the left window" })
-vim.keymap.set("n", "<C-Right>", "<C-w>l", { desc = "Move focus to the right window" })
-vim.keymap.set("n", "<C-Down>", "<C-w>j", { desc = "Move focus to the lower window" })
-vim.keymap.set("n", "<C-Up>", "<C-w>k", { desc = "Move focus to the upper window" })
+vim.keymap.set("n", "<C-S-Left>", "<C-w>h", { desc = "Move focus to the left window" })
+vim.keymap.set("n", "<C-S-Right>", "<C-w>l", { desc = "Move focus to the right window" })
+vim.keymap.set("n", "<C-S-Down>", "<C-w>j", { desc = "Move focus to the lower window" })
+vim.keymap.set("n", "<C-S-Up>", "<C-w>k", { desc = "Move focus to the upper window" })
 
 -- Resizing windows
 vim.keymap.set("n", "<M-h>", "<cmd>vertical resize -2<cr>", { desc = "Shrink window horizontally" })

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -17,8 +17,8 @@ if-shell "uname | grep -q Darwin" \
 if-shell "uname | grep -q Darwin" \
     "bind-key -n C-v run 'pbpaste | tmux load-buffer - ; tmux paste-buffer'" \
     "bind-key -n C-v run 'wl-paste --no-newline | tmux load-buffer - ; tmux paste-buffer'"
-bind-key -n C-h previous-window
-bind-key -n C-s next-window
+bind-key -n C-Left previous-window
+bind-key -n C-Right next-window
 
 set -g status-bg "#1E202F"
 


### PR DESCRIPTION
- tmux: Use Ctrl+Left/Right for window switching (replacing Ctrl+h/s)
- Neovim: Use Ctrl+Shift+Arrow for window navigation (replacing Ctrl+Arrow)
- Kitty: Pass through Ctrl+Shift+Arrow keys to applications

This separation prevents keybinding conflicts between tmux and Neovim, providing clearer mental model: Ctrl+Arrow for tmux-level navigation, Ctrl+Shift+Arrow for Neovim-level navigation.
