### PR TITLE
Update profile based config

### DIFF
--- a/.config/kitty/kitty.conf
+++ b/.config/kitty/kitty.conf
@@ -21,6 +21,9 @@ bold_font        auto
 italic_font      auto
 bold_italic_font auto
 
+# Profile-specific overrides (work.conf or personal.conf)
+include ${MACHINE_PROFILE}.conf
+
 
 # BEGIN_KITTY_THEME
 # Tokyo Night Moon

--- a/.config/kitty/work.conf
+++ b/.config/kitty/work.conf
@@ -1,0 +1,1 @@
+font_size 16

--- a/.stow-local-ignore
+++ b/.stow-local-ignore
@@ -5,3 +5,4 @@
 \.git
 \.pre-commit-config.yaml
 \stylua.toml
+stow\.sh

--- a/README.md
+++ b/README.md
@@ -13,12 +13,15 @@ A collection of dotfiles for easy setup and configurations of Linux distribution
 ```
 git clone git@github.com:miguelcsilva/dotfiles.git
 ```
-### 4. Navigate to the repo and create the symlinks to the home directory
+### 4. Set machine profile
+Add `export MACHINE_PROFILE=work` or `export MACHINE_PROFILE=personal` to `~/.zshrc.local`.
+
+### 5. Navigate to the repo and create the symlinks to the home directory
 ```
 cd path/to/repository
-stow . -t ~/
+./stow.sh
 ```
-### 5. Configure the `~/.gitconfig.private` files
+### 6. Configure the `~/.gitconfig.private` files
 ```
 cp ~/.gitconfig.private.example ~/.gitconfig.private.personal
 cp ~/.gitconfig.private.example ~/.gitconfig.private.work

--- a/stow.sh
+++ b/stow.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+STOW_ARGS=(--target="$HOME" --restow .)
+
+if [[ "${MACHINE_PROFILE:-}" == "work" ]]; then
+    STOW_ARGS+=(--ignore='\.claude/commands' --ignore='\.claude/skills')
+fi
+
+stow "${STOW_ARGS[@]}"


### PR DESCRIPTION
Replace OS-based conditionals with a MACHINE_PROFILE env var to differentiate work and personal machines. Adds stow.sh to conditionally ignore .claude dirs on work, and switches kitty includes from OS-based to profile-based.