### PR TITLE
Add zsh-vi-mode and auto-bootstrap TPM

### DIFF
--- a/common/.config/tmux/tmux.conf
+++ b/common/.config/tmux/tmux.conf
@@ -36,5 +36,9 @@ set -g @continuum-restore 'on'
 
 set -g @plugin 'tmux-plugins/tpm'
 
+# Bootstrap TPM if not installed
+if "test ! -d ~/.config/tmux/plugins/tpm" \
+   "run 'git clone https://github.com/tmux-plugins/tpm ~/.config/tmux/plugins/tpm && ~/.config/tmux/plugins/tpm/bin/install_plugins'"
+
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 run '~/.config/tmux/plugins/tpm/tpm'

--- a/common/.zshrc
+++ b/common/.zshrc
@@ -69,6 +69,9 @@ pcodex() {
 
 # Plugins
 
+## Vi mode
+zinit light jeffreytse/zsh-vi-mode
+
 ## Syntax highlighting
 zinit light zsh-users/zsh-syntax-highlighting
 
@@ -117,9 +120,9 @@ eval "$(zoxide init zsh)"
 eval "$(direnv hook zsh)"
 
 # Keybindings
-bindkey -v
-KEYTIMEOUT=1
-bindkey '^y' autosuggest-accept
+zvm_after_init() {
+  bindkey '^y' autosuggest-accept
+}
 
 # Completion styling
 zstyle ':completion:*' matcher-list 'm:{a-z}={A-Za-z}'


### PR DESCRIPTION
# Summary
**Title:** Add zsh-vi-mode and auto-bootstrap TPM

Reviewers: miguelcsilva

## Description
Add full vim modal editing on the zsh command line via zsh-vi-mode, and make TPM self-bootstrap on first tmux launch so new machines need no manual plugin setup.

## Changes
- Add `jeffreytse/zsh-vi-mode` via Zinit, replacing basic `bindkey -v` — brings text objects, surround, visual mode, and cursor shape feedback
- Move `^y` autosuggest binding into `zvm_after_init` hook so it survives zvm's keybinding reset
- Auto-clone TPM and install plugins if `~/.config/tmux/plugins/tpm` is missing

## Additional Notes
If fzf keybindings (`Ctrl+R`, `Ctrl+T`) break, the fix is moving `eval "$(fzf --zsh)"` into the `zvm_after_init` hook as well.