### PR TITLE
Enable OSC-52 clipboard passthrough (tmux + kitty)

### DIFF
--- a/.config/kitty/kitty.conf
+++ b/.config/kitty/kitty.conf
@@ -5,8 +5,7 @@ background_blur         10
 # Options
 macos_option_as_alt yes
 
-# Allow apps (incl. remote over ssh/tmux via OSC-52) to write the clipboard,
-# with no size cap so large copies aren't silently dropped.
+# OSC-52 clipboard access, no size cap
 clipboard_control write-clipboard write-primary read-clipboard read-primary
 clipboard_max_size 0
 

--- a/.config/kitty/kitty.conf
+++ b/.config/kitty/kitty.conf
@@ -5,6 +5,11 @@ background_blur         10
 # Options
 macos_option_as_alt yes
 
+# Allow apps (incl. remote over ssh/tmux via OSC-52) to write the clipboard,
+# with no size cap so large copies aren't silently dropped.
+clipboard_control write-clipboard write-primary read-clipboard read-primary
+clipboard_max_size 0
+
 # Keybindings
 map ctrl+v paste_from_clipboard
 

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -8,8 +8,7 @@ bind-key C-Space send-prefix
 set-window-option -g mode-keys vi
 bind-key -T copy-mode-vi 'v' send -X begin-selection
 
-# Forward OSC-52 clipboard escapes (e.g. from a remote box over ssh) up to the
-# terminal so they reach the system clipboard.
+# Forward OSC-52 clipboard escapes (e.g. from a remote box) to the terminal
 set -g set-clipboard on
 set -g allow-passthrough on
 

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -8,6 +8,11 @@ bind-key C-Space send-prefix
 set-window-option -g mode-keys vi
 bind-key -T copy-mode-vi 'v' send -X begin-selection
 
+# Forward OSC-52 clipboard escapes (e.g. from a remote box over ssh) up to the
+# terminal so they reach the system clipboard.
+set -g set-clipboard on
+set -g allow-passthrough on
+
 # OS-specific clipboard copy integration
 if-shell "uname | grep -q Darwin" \
     "bind-key -T copy-mode-vi 'y' send -X copy-pipe-and-cancel 'pbcopy'" \

--- a/.zshrc
+++ b/.zshrc
@@ -206,8 +206,7 @@ alias ld="lazydocker"
 alias lg="lazygit"
 alias uvr="uv run"
 
-# Copy stdin to the system clipboard via OSC-52 (works over ssh). Wraps the
-# escape for tmux passthrough when inside a tmux session. Usage: cat file | clip
+# Copy stdin to clipboard via OSC-52 (tmux-aware). Usage: cat file | clip
 clip() {
   local b64 osc
   b64=$(base64 | tr -d '\n')

--- a/.zshrc
+++ b/.zshrc
@@ -206,6 +206,19 @@ alias ld="lazydocker"
 alias lg="lazygit"
 alias uvr="uv run"
 
+# Copy stdin to the system clipboard via OSC-52 (works over ssh). Wraps the
+# escape for tmux passthrough when inside a tmux session. Usage: cat file | clip
+clip() {
+  local b64 osc
+  b64=$(base64 | tr -d '\n')
+  osc="\033]52;c;${b64}\a"
+  if [ -n "$TMUX" ]; then
+    printf "\033Ptmux;\033%s\033\\" "$osc"
+  else
+    printf "%b" "$osc"
+  fi
+}
+
 # Source local config if it exists
 [[ -f ~/.zshrc.local ]] && source ~/.zshrc.local
 


### PR DESCRIPTION
Copying from a remote box over ssh (OSC-52) silently failed. Local tmux wraps kitty, and it had `allow-passthrough off` + `set-clipboard external`, so it dropped the OSC-52 escape before kitty could write the clipboard.

## Changes
- **tmux**: `set-clipboard on` + `allow-passthrough on` so remote OSC-52 escapes are forwarded to the terminal.
- **kitty**: explicit `clipboard_control` (write/read) + `clipboard_max_size 0` so large copies are not silently truncated.

## Test
- tmux config loads; live values show `allow-passthrough on`, `set-clipboard on`.
- After reloading tmux + kitty, `printf "\\033]52;c;%s\\007" "$(printf hello | base64)"` on a remote box lands `hello` in the macOS clipboard.