### PR TITLE
chmod +x tree-sitter after zinit install

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -111,7 +111,7 @@ zinit light BurntSushi/ripgrep
 ## Tree-sitter
 if ! ismac; then
   zinit ice from"gh-r" as"program" bpick"tree-sitter-linux-x64.gz" \
-    mv"tree-sitter* -> tree-sitter"
+    mv"tree-sitter* -> tree-sitter" atclone"chmod +x tree-sitter" atpull"%atclone"
   zinit light tree-sitter/tree-sitter
 fi
 


### PR DESCRIPTION
The tree-sitter release ships a bare gzipped binary, and `gunzip` drops the execute bit — so after install the binary was not executable and nvim-treesitter failed with `EACCES: permission denied (cmd): tree-sitter` when compiling parsers.

Add `atclone"chmod +x tree-sitter"` + `atpull"%atclone"` so zinit marks it executable on install and on update.

## Test
- `zsh -n .zshrc` passes.
- Verified on a research box: after `chmod +x`, `tree-sitter --version` prints and `:TSInstall` compiles parsers (a C compiler is present there).